### PR TITLE
Date Management for meal scheduling:

### DIFF
--- a/Food@Home/Constants.swift
+++ b/Food@Home/Constants.swift
@@ -13,6 +13,7 @@ let brandPink: Color = Color.init(hex: 0xE9BAD5)
 let brandPurple: Color = Color.init(hex: 0xA078B4)
 let brandWarm: Color = Color.init(hex: 0xFEF7D7)
 let brandOrange: Color = Color.init(hex: 0xEFAD5C)
+let disabledWarm: Color = Color.init(hex: 0xC4C1BC)
 let brandGreen: Color = Color.init(hex: 0x036E5B)
 
 let textPink: Color = Color.init(hex: 0xFCDAE2)

--- a/Food@Home/MainTabs/Home/HomeView/Components/dateBubble.swift
+++ b/Food@Home/MainTabs/Home/HomeView/Components/dateBubble.swift
@@ -21,7 +21,7 @@ struct dateBubble: View {
                         .frame(width: 40, height: 40)
                 } else {
                     Circle()
-                        .fill(day == selectedDate ? brandOrange : brandWarm)
+                        .fill(day == selectedDate ? brandOrange : withinDateRange(day) ? brandWarm : disabledWarm)
                         .frame(width: 40, height: 40)
                 }
                 

--- a/Food@Home/MainTabs/Home/HomeView/HomeView.swift
+++ b/Food@Home/MainTabs/Home/HomeView/HomeView.swift
@@ -73,11 +73,12 @@ struct HomeView: View {
                 Button(action: {
                     path.append(1)
                 }, label: {
-                    Text("Plan your meal")
+                    Text(withinDateRange(viewModel.selectedDate) ? "Plan your meal" : "Date unavailable for planning")
                         .button(color: "black")
                         .padding(.bottom, 38)
                 })
                 .buttonStyle(.plain)
+                .disabled(!withinDateRange(viewModel.selectedDate))
                 
                 SeparatorLine()
             }
@@ -85,7 +86,7 @@ struct HomeView: View {
                 MenuView(selectedDate: viewModel.selectedDate, path: $path)
             }
             .navigationDestination(for: Recipe.self) { recipe in
-                RecipeDetailsView(id: recipe.id, path: $path)
+                RecipeDetailsView(selectedDate: viewModel.selectedDate,id: recipe.id, path: $path)
             }
             .navigationDestination(for: Date.self) { date in
                 WeekReviewView(date: date, meals: meals, path: $path)

--- a/Food@Home/MainTabs/Home/HomeViewModel.swift
+++ b/Food@Home/MainTabs/Home/HomeViewModel.swift
@@ -43,5 +43,4 @@ import Foundation
             }
         }
     }
-//}
 

--- a/Food@Home/ReuseableViews/RecipeDetails/Components/MealScheduler/Components/TimeSelector.swift
+++ b/Food@Home/ReuseableViews/RecipeDetails/Components/MealScheduler/Components/TimeSelector.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 struct TimeSelector: View {
-    @Binding var timeSelectorObject: timeSelectorObject
-    let mealTimeArray = ["Breakfast", "Lunch", "Snack", "Dinner"]
-    let firstSelector: Bool = false
     
     @State var delete: Bool = false
     @State private var dragAmount = CGSize.zero
-    
+    let firstSelector: Bool = false
+    let mealTimeArray = ["Breakfast", "Lunch", "Snack", "Dinner"]
+    let specificDateSelect: () -> [Date]
+    @Binding var timeSelectorObject: TimeSelectorObject
+        
     var body: some View {
         VStack {
             Group{
@@ -34,6 +35,7 @@ struct TimeSelector: View {
                                 DatePicker(
                                     "",
                                     selection: $timeSelectorObject.date,
+                                    in: Date()...Date().addingTimeInterval(TimeInterval(86400 * 13)),
                                     displayedComponents: [.date]
                                 )
                                 .blendMode(.destinationOver)
@@ -120,17 +122,17 @@ struct TimeSelector: View {
 
 #Preview {
     struct PreviewWrapper: View {
-        @State var object = timeSelectorObject( date: Date())
+        @State var object = TimeSelectorObject( date: Date())
         var body: some View {
             
-            TimeSelector(timeSelectorObject: $object)
+            TimeSelector(specificDateSelect: {[Date()]}, timeSelectorObject: $object)
         }
     }
     return PreviewWrapper()
 }
 
 
-struct timeSelectorObject: Identifiable, Equatable {
+struct TimeSelectorObject: Identifiable, Equatable {
     var id = UUID()
     var isDisclosed: Bool = false
     var mealTimes = ["Breakfast": false, "Lunch": false, "Dinner": false, "Snack": false]

--- a/Food@Home/UniversalFunctions.swift
+++ b/Food@Home/UniversalFunctions.swift
@@ -8,10 +8,17 @@
 import Foundation
 import SwiftUI
 
-//func binding(for key: String) -> Binding<Bool> {
-//    return Binding(get: {
-//        return timeSelectorObject.mealTimes[key] ?? false
-//    }, set: {
-//        timeSelectorObject.mealTimes[key] = $0
-//    })
-//}
+func areSameDate(_ date1: Date, _ date2: Date) -> Bool {
+    let calendar = Calendar.current
+    let components1 = calendar.dateComponents([.year, .month, .day], from: date1)
+    let components2 = calendar.dateComponents([.year, .month, .day], from: date2)
+
+    return components1.year == components2.year &&
+           components1.month == components2.month &&
+           components1.day == components2.day
+}
+
+func withinDateRange(_ date: Date) -> Bool  {
+    let range = Calendar.current.startOfDay(for: Date())...Date().addingTimeInterval(TimeInterval(86400 * 13))
+    return range ~= date
+}


### PR DESCRIPTION
* Disabled color for date bubbles out of range
* Disable functionality for planning a meal in the past or more than 2 weeks in the future
* Restrict date choices in TimeSelector
* Update TimeSelectorObject naming convention
* MealScheduler dynamic addition to list. Will add a new selector for next available day and not just the same day again
* MealScheduler maxing out timeSelector objects when it fills out potential plans for the next two weeks
* Groundwork for specific dates being restricted on Calendar picker
* Adding Date comparison functions to universal functions list